### PR TITLE
Only re apply offsets if the realloc has needed to move the memory block

### DIFF
--- a/src/Payload.cpp
+++ b/src/Payload.cpp
@@ -224,18 +224,20 @@ OmnmPayloadImpl::updateField (omnmFieldImpl& field, uint8_t* buffer,
         // Increase the buffer *if necessary*
         if (delta > 0)
         {
-            // Cache pointer indices from main buffer
-            int dataOffset = (uint8_t*)field.mData - mPayloadBuffer;
-            int nameOffset = (uint8_t*)field.mName - mPayloadBuffer;
+            const uint8_t* payloadBufferPrev = mPayloadBuffer;
 
             // Increase buffer memory
             allocateBufferMemory ((void**)&mPayloadBuffer,
                                   &mPayloadBufferSize,
                                   mPayloadBufferSize + delta);
 
-            // Assume buffers have moved and re-apply offsets
-            field.mData = mPayloadBuffer + dataOffset;
-            field.mName = (const char*)mPayloadBuffer + nameOffset;
+            // If the allocateBufferMemory (realloc) has actually moved the underlying buffer
+            if(payloadBufferPrev != mPayloadBuffer)
+            {
+              // buffers have moved so re-apply offsets
+              field.mData = mPayloadBuffer + ((uint8_t*)field.mData - payloadBufferPrev);
+              field.mName = (const char*)mPayloadBuffer + ((uint8_t*)field.mName - payloadBufferPrev);
+            }
         }
 
         // If the field has changed in size, we need to move memory


### PR DESCRIPTION
I ran some tests with market data on the previous change (reset offsets rather than calling find) which worked perfectly. I also added some temp metrics to see how often the realloc moves vs grows.

Results:
When increasing buffer size with allocateBufferMemory only around 10% of calls result in a realloc having to move the memory block, most of the time the buffer has room to grow without moving.

With this in mind I have made the re calculation of offsets apply only if the memory moved.  
